### PR TITLE
Add QtFeedback plugin

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 Ngf::Client
 ===========
 
-Source: https://git.merproject.org/mer-core/libngf-qt/
+Source: https://github.com/sailfishos/libngf-qt/
 
 Qt-based client for NGF daemon (Non-Graphic Feedback).
 

--- a/feedback/feedback.pro
+++ b/feedback/feedback.pro
@@ -1,0 +1,24 @@
+TEMPLATE = lib
+
+QT += core feedback
+CONFIG += qt plugin hide_symbols
+QT -= gui
+
+TARGET = $$qtLibraryTarget(qtfeedback_libngf)
+PLUGIN_TYPE = feedback
+
+LIBS += -L../src/ -lngf-qt5
+INCLUDEPATH += ../src/include
+
+HEADERS += ngffeedback.h
+
+SOURCES += ngffeedback.cpp
+
+OTHER_FILES += libngf.json
+
+target.path = $$[QT_INSTALL_PLUGINS]/feedback
+INSTALLS += target
+
+plugindescription.files = libngf.json
+plugindescription.path = $$[QT_INSTALL_PLUGINS]/feedback/
+INSTALLS += plugindescription

--- a/feedback/libngf.json
+++ b/feedback/libngf.json
@@ -1,0 +1,1 @@
+{ "Interfaces": [ "QFeedbackHapticsInterface", "QFeedbackThemeInterface" ] }

--- a/feedback/ngffeedback.cpp
+++ b/feedback/ngffeedback.cpp
@@ -1,0 +1,324 @@
+/*
+ * Copyright (c) 2021 Jolla Ltd.
+ *
+ * This file is part of the libngf QtFeedback plugin.
+ * Based on qt5-feedback-hapticks-droid-vibrator.
+ *
+ * This work is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1 as published by the Free Software Foundation.
+ *
+ * This work is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this work; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#include <qfeedbackeffect.h>
+#include <QCoreApplication>
+#include <QtPlugin>
+#include "ngffeedback.h"
+
+Q_LOGGING_CATEGORY(ngflc, "qt.Feedback.ngf", QtWarningMsg)
+
+NGFFeedback::NGFFeedback(QObject *parent)
+    : QObject(parent)
+    , QFeedbackHapticsInterface()
+    , QFeedbackThemeInterface()
+    , m_actuator(createFeedbackActuator(this, 2))
+    , m_actuatorEnabled(true)
+    , m_client(this)
+{
+    qCDebug(ngflc) << "Initializing plugin";
+
+    if (!m_client.connect()) {
+        qCCritical(ngflc) << "Unable to connect to NGFD";
+    }
+
+    connect(&m_client, &Ngf::Client::eventFailed,
+            this, &NGFFeedback::failed);
+    connect(&m_client, &Ngf::Client::eventCompleted,
+            this, &NGFFeedback::completed);
+    connect(&m_client, &Ngf::Client::eventPlaying,
+            this, &NGFFeedback::playing);
+    connect(&m_client, &Ngf::Client::eventPaused,
+            this, &NGFFeedback::paused);
+
+    m_effects[QFeedbackEffect::Press] = QStringLiteral("feedback_press");
+    m_effects[QFeedbackEffect::Release] = QStringLiteral("feedback_release");
+    m_effects[QFeedbackEffect::PressWeak] = QStringLiteral("feedback_press_weak");
+    m_effects[QFeedbackEffect::ReleaseWeak] = QStringLiteral("feedback_release_weak");
+    m_effects[QFeedbackEffect::PressStrong] = QStringLiteral("feedback_press_strong");
+    m_effects[QFeedbackEffect::ReleaseStrong] = QStringLiteral("feedback_release_strong");
+    m_effects[QFeedbackEffect::DragStart] = QStringLiteral("feedback_drag_start");
+    m_effects[QFeedbackEffect::DragDropInZone] = QStringLiteral("feedback_drag_drop_in_zone");
+    m_effects[QFeedbackEffect::DragDropOutOfZone] = QStringLiteral("feedback_drag_drop_out_of_zone");
+    m_effects[QFeedbackEffect::DragCrossBoundary] = QStringLiteral("feedback_drag_cross_boundary");
+    m_effects[QFeedbackEffect::Appear] = QString();
+    m_effects[QFeedbackEffect::Disappear] = QString();
+    m_effects[QFeedbackEffect::Move] = QString();
+}
+
+NGFFeedback::~NGFFeedback()
+{
+    qCDebug(ngflc) << "Deinitializing plugin";
+}
+
+void NGFFeedback::failed(quint32 id)
+{
+    ActiveEffect *active = findEffect(id);
+    if (active)
+        m_activeEffects.removeAll(*active);
+    qCWarning(ngflc) << "Effect failed, id" << id;
+}
+
+void NGFFeedback::completed(quint32 id)
+{
+    ActiveEffect *active = findEffect(id);
+    if (active)
+        m_activeEffects.removeAll(*active);
+    qCDebug(ngflc) << "Effect completed, id" << id;
+}
+
+void NGFFeedback::playing(quint32 id)
+{
+    ActiveEffect *active = findEffect(id);
+    if (active)
+        active->state = QFeedbackEffect::Running;
+    qCDebug(ngflc) << "Effect playing, id" << id;
+}
+
+void NGFFeedback::paused(quint32 id)
+{
+    ActiveEffect *active = findEffect(id);
+    if (active)
+        active->state = QFeedbackEffect::Paused;
+    qCDebug(ngflc) << "Effect paused, id" << id;
+}
+
+bool NGFFeedback::play(QFeedbackEffect::Effect effect)
+{
+    quint32 id;
+    switch (effect) {
+    case QFeedbackEffect::Press:
+    case QFeedbackEffect::Release:
+    case QFeedbackEffect::PressWeak:
+    case QFeedbackEffect::ReleaseWeak:
+    case QFeedbackEffect::PressStrong:
+    case QFeedbackEffect::ReleaseStrong:
+    case QFeedbackEffect::DragStart:
+    case QFeedbackEffect::DragDropInZone:
+    case QFeedbackEffect::DragDropOutOfZone:
+    case QFeedbackEffect::DragCrossBoundary:
+        /* These are quick effects and the status can not be retrieved
+         * via effectState() anyway, thus this is not storing the id.
+         */
+        id = m_client.play(m_effects[effect]);
+        if (!id)
+            qCWarning(ngflc) << "Could not play effect";
+        qCDebug(ngflc) << "Playing effect #" << effect << "(" << m_effects[effect] << ") with id" << id;
+        return true;
+    case QFeedbackEffect::Appear:
+    case QFeedbackEffect::Disappear:
+    case QFeedbackEffect::Move:
+        qCDebug(ngflc) << "Unsupported effect #" << effect;
+        break;
+    default:
+        qCDebug(ngflc) << "Unknown or undefined effect #" << effect;
+        break;
+    }
+
+    return false;
+}
+
+QFeedbackInterface::PluginPriority NGFFeedback::pluginPriority()
+{
+    return QFeedbackInterface::PluginLowPriority;
+}
+
+QList<QFeedbackActuator*> NGFFeedback::actuators()
+{
+    return QList<QFeedbackActuator*>() << m_actuator;
+}
+
+void NGFFeedback::setActuatorProperty(const QFeedbackActuator &, ActuatorProperty prop, const QVariant &value)
+{
+    if (prop == ActuatorProperty::Enabled) {
+        bool old = m_actuatorEnabled;
+        m_actuatorEnabled = value.toBool();
+        if (old != m_actuatorEnabled && !m_actuatorEnabled) {
+            // Stop all effects
+            for (auto it = m_activeEffects.begin(); it != m_activeEffects.end(); it = m_activeEffects.erase(it)) {
+                if (!m_client.stop(it->id)) {
+                    qCWarning(ngflc) << "Could not stop effect with id" << it->id;
+                    if (it->effect)
+                        reportError(it->effect, QFeedbackEffect::UnknownError);
+                }
+            }
+            qCDebug(ngflc) << "Stopped all effects";
+        }
+    }
+}
+
+QVariant NGFFeedback::actuatorProperty(const QFeedbackActuator &, ActuatorProperty prop)
+{
+    switch (prop) {
+    case Name:
+        return QLatin1String("NGFD");
+    case State:
+        return QFeedbackActuator::Ready;
+    case Enabled:
+        return m_actuatorEnabled;
+    default:
+        return QVariant();
+    }
+}
+
+bool NGFFeedback::isActuatorCapabilitySupported(const QFeedbackActuator &, QFeedbackActuator::Capability)
+{
+    /* Changing envelope or periodicity is not supported
+     * since we don't support changing intensity level.
+     */
+    return false;
+}
+
+void NGFFeedback::updateEffectProperty(const QFeedbackHapticsEffect *effect, QFeedbackHapticsInterface::EffectProperty prop)
+{
+    if (!m_actuatorEnabled)
+        return;
+
+    ActiveEffect *active = findCustomEffect(effect);
+    if (!active)
+        return;
+
+    if (prop == QFeedbackHapticsInterface::Duration) {
+        qCDebug(ngflc) << "Playing custom effect due to property update (" << effect->duration() << "ms)";
+        setEffectState(effect, QFeedbackEffect::Running);
+    }
+}
+
+void NGFFeedback::setEffectState(const QFeedbackHapticsEffect *effect, QFeedbackEffect::State state)
+{
+    if (!m_actuatorEnabled)
+        return;
+
+    ActiveEffect *active = findCustomEffect(effect);
+
+    switch (state) {
+    case QFeedbackEffect::Running:
+        if (active && active->state == QFeedbackEffect::Paused)
+            resumeCustomEffect(active);
+        else
+            startCustomEffect(active, effect);
+        break;
+    case QFeedbackEffect::Stopped:
+        stopCustomEffect(active);
+        break;
+    case QFeedbackEffect::Paused:
+        pauseCustomEffect(active);
+        break;
+    case QFeedbackEffect::Loading:
+    default:
+        // not supported
+        break;
+    }
+}
+
+QFeedbackEffect::State NGFFeedback::effectState(const QFeedbackHapticsEffect *effect)
+{
+    ActiveEffect *active = findCustomEffect(effect);
+    if (active)
+        return active->state;
+    return QFeedbackEffect::Stopped;
+}
+
+NGFFeedback::ActiveEffect *NGFFeedback::findEffect(quint32 id)
+{
+    // Assuming that there aren't too many effects
+    for (ActiveEffect &active : m_activeEffects)
+        if (active.id == id)
+            return &active;
+    return nullptr;
+}
+
+NGFFeedback::ActiveEffect *NGFFeedback::findCustomEffect(const QFeedbackHapticsEffect *effect)
+{
+    // Assuming that there aren't too many effects
+    for (ActiveEffect &active : m_activeEffects)
+        if (active.effect == effect)
+            return &active;
+    return nullptr;
+}
+
+void NGFFeedback::startCustomEffect(ActiveEffect *active, const QFeedbackHapticsEffect *effect)
+{
+    if (effect->duration() > 0) {
+        qCDebug(ngflc) << "Playing custom effect due to state change (" << effect->duration() << "ms)";
+        QMap<QString, QVariant> properties;
+        properties.insert(QStringLiteral("haptic.duration"),
+                          QVariant(static_cast<quint32>(effect->duration())));
+        if (active) { // Existing effect
+            m_client.stop(active->id);
+            m_activeEffects.removeAll(*active);
+        }
+        /* The choice of the effect will only affect the strength and style
+         * of the feedback. Duration is determined by haptic.duration property
+         * which either repeats or "stretches" the effect to the whole duration.
+         */
+        quint32 id = m_client.play(QStringLiteral("feedback_press"), properties);
+        if (!id) {
+            qCWarning(ngflc) << "Could not play effect";
+            reportError(effect, QFeedbackEffect::UnknownError);
+        } else {
+            // Report already the expected state
+            m_activeEffects.append({ id, QFeedbackEffect::Running, const_cast<QFeedbackHapticsEffect *>(effect) });
+        }
+    }
+}
+
+void NGFFeedback::stopCustomEffect(ActiveEffect *active)
+{
+    if (active) {
+        qCDebug(ngflc) << "Stopping custom effect due to state change";
+        if (!m_client.stop(active->id)) {
+            qCWarning(ngflc) << "Could not stop effect with id" << active->id;
+            m_activeEffects.removeAll(*active);
+            reportError(active->effect, QFeedbackEffect::UnknownError);
+        } else {
+            // Report already the expected state
+            active->state = QFeedbackEffect::Stopped;
+        }
+    }
+}
+
+void NGFFeedback::pauseCustomEffect(ActiveEffect *active)
+{
+    if (active) {
+        qCDebug(ngflc) << "Pausing custom effect due to state change";
+        if (!m_client.pause(active->id)) {
+            qCWarning(ngflc) << "Could not pause effect with id" << active->id;
+            reportError(active->effect, QFeedbackEffect::UnknownError);
+        } else {
+            // Report already the expected state
+            active->state = QFeedbackEffect::Paused;
+        }
+    }
+}
+
+void NGFFeedback::resumeCustomEffect(ActiveEffect *active)
+{
+    if (active) {
+        qCDebug(ngflc) << "Resuming custom effect due to state change";
+        if (!m_client.resume(active->id)) {
+            qCWarning(ngflc) << "Could not resume effect with id" << active->id;
+            reportError(active->effect, QFeedbackEffect::UnknownError);
+        } else {
+            // Report already the expected state
+            active->state = QFeedbackEffect::Running;
+        }
+    }
+}

--- a/feedback/ngffeedback.h
+++ b/feedback/ngffeedback.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2021 Jolla Ltd.
+ *
+ * This file is part of the libngf QtFeedback plugin.
+ * Based on qt5-feedback-hapticks-droid-vibrator.
+ *
+ * This work is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1 as published by the Free Software Foundation.
+ *
+ * This work is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this work; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#ifndef NGF_FEEDBACK_H
+#define NGF_FEEDBACK_H
+
+#include <QObject>
+#include <QLoggingCategory>
+#include <qfeedbackplugininterfaces.h>
+#include "ngfclient.h"
+
+class NGFFeedback : public QObject, public QFeedbackHapticsInterface, public QFeedbackThemeInterface {
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "org.qt-project.Qt.QtFeedbackPlugin" FILE "libngf.json")
+    Q_INTERFACES(QFeedbackHapticsInterface)
+    Q_INTERFACES(QFeedbackThemeInterface)
+
+public:
+    NGFFeedback(QObject *parent = 0);
+    ~NGFFeedback();
+
+    virtual bool play(QFeedbackEffect::Effect) override;
+    virtual QFeedbackInterface::PluginPriority pluginPriority() override;
+
+    virtual QList<QFeedbackActuator*> actuators() override;
+    virtual void setActuatorProperty(const QFeedbackActuator &, ActuatorProperty, const QVariant &) override;
+    virtual QVariant actuatorProperty(const QFeedbackActuator &, ActuatorProperty) override;
+    virtual bool isActuatorCapabilitySupported(const QFeedbackActuator &, QFeedbackActuator::Capability) override;
+    virtual void updateEffectProperty(const QFeedbackHapticsEffect *, EffectProperty) override;
+    virtual void setEffectState(const QFeedbackHapticsEffect *, QFeedbackEffect::State) override;
+    virtual QFeedbackEffect::State effectState(const QFeedbackHapticsEffect *) override;
+
+private slots:
+    void failed(quint32 id);
+    void completed(quint32 id);
+    void playing(quint32 id);
+    void paused(quint32 id);
+
+private:
+    struct ActiveEffect {
+        quint32 id;
+        QFeedbackEffect::State state;
+        QFeedbackHapticsEffect *effect;
+
+        bool operator==(const ActiveEffect &other) const {
+            return id == other.id && state == other.state && effect == other.effect;
+        }
+    };
+
+    ActiveEffect *findEffect(quint32 id);
+    ActiveEffect *findCustomEffect(const QFeedbackHapticsEffect *effect);
+
+    void startCustomEffect(ActiveEffect *active, const QFeedbackHapticsEffect *effect);
+    void stopCustomEffect(ActiveEffect *active);
+    void pauseCustomEffect(ActiveEffect *active);
+    void resumeCustomEffect(ActiveEffect *active);
+
+    QFeedbackActuator *m_actuator;
+    bool m_actuatorEnabled;
+    QVector<ActiveEffect> m_activeEffects;
+
+    Ngf::Client m_client;
+    QString m_effects[QFeedbackEffect::NumberOfEffects];
+};
+
+#endif // NGF_FEEDBACK_H

--- a/libngf-qt.pro
+++ b/libngf-qt.pro
@@ -1,9 +1,12 @@
-CONFIG += ordered
 isEmpty(PREFIX) {
     PREFIX = /usr/local
 }
 TEMPLATE = subdirs
-SUBDIRS += src declarative tests
+SUBDIRS += src declarative tests feedback
+
+declarative.depends = src
+tests.depends = src declarative
+feedback.depends = src
 
 # No need to build this, but if you want then 'qmake EXAMPLE=1 && make'
 count(EXAMPLE, 1) {

--- a/rpm/libngf-qt5.spec
+++ b/rpm/libngf-qt5.spec
@@ -1,6 +1,6 @@
 Name:       libngf-qt5
 Summary:    Qt-based client library for Non-Graphic Feedback daemon
-Version:    0.7.0
+Version:    0.8.0
 Release:    1
 License:    LGPLv2
 URL:        https://github.com/sailfishos/libngf-qt
@@ -12,6 +12,7 @@ BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5DBus)
 BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5Test)
+BuildRequires:  pkgconfig(Qt5Feedback)
 BuildRequires:  doxygen
 
 %description
@@ -19,9 +20,20 @@ This package contains the Qt-based client library for accessing
 Non-graphic feedback services.
 
 
+%package qtfeedback
+Summary:    QtFeedback plugin for Non-Graphic Feedback daemon
+Requires:   %{name} = %{version}-%{release}
+Requires(post):   /sbin/ldconfig
+Requires(postun): /sbin/ldconfig
+
+Obsoletes:  qt5-feedback-haptics-native-vibrator < 0.2.1+git1
+Provides:   qt5-feedback-haptics-native-vibrator = 0.2.1+git1
+
+%description qtfeedback
+%{summary}.
+
 %package devel
 Summary:    Development package for Qt-based client library for NGF daemon
-Group:      Development/Libraries
 Requires:   %{name} = %{version}-%{release}
 
 %description devel
@@ -29,7 +41,6 @@ Requires:   %{name} = %{version}-%{release}
 
 %package declarative
 Summary:    Declarative plugin for NGF clients
-Group:      Development/Libraries
 Requires:   %{name} = %{version}-%{release}
 
 %description declarative
@@ -69,6 +80,11 @@ sed 's/Nemo.Ngf/org.nemomobile.ngf/' < declarative/qmldir > %{buildroot}%{_libdi
 %defattr(-,root,root,-)
 %{_libdir}/libngf-qt5.so.*
 %license COPYING
+
+%files qtfeedback
+%defattr(-,root,root,-)
+%{_libdir}/qt5/plugins/feedback/libqtfeedback_libngf.so
+%{_libdir}/qt5/plugins/feedback/libngf.json
 
 %files devel
 %defattr(-,root,root,-)

--- a/rpm/libngf-qt5.spec
+++ b/rpm/libngf-qt5.spec
@@ -3,7 +3,7 @@ Summary:    Qt-based client library for Non-Graphic Feedback daemon
 Version:    0.7.0
 Release:    1
 License:    LGPLv2
-URL:        https://git.sailfishos.org/mer-core/libngf-qt
+URL:        https://github.com/sailfishos/libngf-qt
 Source0:    %{name}-%{version}.tar.bz2
 Requires:   ngfd
 Requires(post): /sbin/ldconfig


### PR DESCRIPTION
Implement libngf based QtFeedback plugin that supports playing, pausing
and resuming of effects although it depends on the backend whether those
will work expectedly. It does not support changing intensity level
although ngfd might set different intensities for different effects.
There needs to be a mapping configuration of the effect names to actual
haptic effects on ngfd side.

See also https://github.com/sailfishos/ngfd/pull/2.