### PR TITLE
[libngf-qt] Avoid emitting playing state twice.

### DIFF
--- a/src/dbus/clientprivate.cpp
+++ b/src/dbus/clientprivate.cpp
@@ -221,8 +221,10 @@ void Ngf::ClientPrivate::eventStatus(quint32 serverEventId, quint32 state)
             break;
 
         case StatusEventPlaying:
-            event->activeState = StatePlaying;
-            emit q_ptr->eventPlaying(event->clientEventId);
+            if (event->activeState != StatePlaying) {
+                event->activeState = StatePlaying;
+                emit q_ptr->eventPlaying(event->clientEventId);
+            }
             break;
 
         case StatusEventPaused:


### PR DESCRIPTION
When calling the "play" method over DBus, if the
DBus reply is positive, the "playing" state is
emitted. Then the ngf daemon is emitting a state
change to "playing" which is transmitted by the
client. This commit is avoiding to transmit this
latter "playing" state in the normal case.

If the daemon is unable to play the effect, then
the "playing" signal is emitted (because the DBus
call succeed) and is then followed by a "failed"
signal, thanks to the state change broadcasted by
ngfd. This commit is not changing this behaviour.

@pvuorela, this is fixing the played twice that we've seen in the harbour-ding reproducer. As explained in the commit message, I chose to keep the "playing" signal emission in the DBus reply, even if it happens that the effect does not exist for instance. To keep the "playing" -> "failed" workflow.