### PR TITLE
[libngf-qt] Use different feedback event for non-touch haptics. JB#60638

### DIFF
--- a/feedback/ngffeedback.cpp
+++ b/feedback/ngffeedback.cpp
@@ -269,7 +269,7 @@ void NGFFeedback::startCustomEffect(ActiveEffect *active, const QFeedbackHaptics
          * of the feedback. Duration is determined by haptic.duration property
          * which either repeats or "stretches" the effect to the whole duration.
          */
-        quint32 id = m_client.play(QStringLiteral("feedback_press"), properties);
+        quint32 id = m_client.play(QStringLiteral("feedback_alert"), properties);
         if (!id) {
             qCWarning(ngflc) << "Could not play effect";
             reportError(effect, QFeedbackEffect::UnknownError);


### PR DESCRIPTION
We have different settings for vibra on/off totally, or on/off only for display touch events. Latter used by the theme effects, former ones going this path.