### PR TITLE
[libngf-qt] Don't warn on play failed signal. Fixes JB#60695

### DIFF
--- a/feedback/ngffeedback.cpp
+++ b/feedback/ngffeedback.cpp
@@ -73,7 +73,8 @@ void NGFFeedback::failed(quint32 id)
     ActiveEffect *active = findEffect(id);
     if (active)
         m_activeEffects.removeAll(*active);
-    qCWarning(ngflc) << "Effect failed, id" << id;
+    // Can fail just because vibra feedbacks are disabled, so don't whine too loudly here
+    qCDebug(ngflc) << "Effect failed, id" << id;
 }
 
 void NGFFeedback::completed(quint32 id)


### PR DESCRIPTION
The failed signal can come from just settings having haptic feedback turned off. On such case we shouldn't constantly spam the journal.

Could be debated whether haptic settings should result in play request failing vs just silently ignoring it, but at the moment ngfd plugin interface explicitly defines it this way.