### PR TITLE
[libngf-qt] Make multiple state changes more robust. JB#61050

### DIFF
--- a/src/dbus/clientprivate.h
+++ b/src/dbus/clientprivate.h
@@ -64,12 +64,12 @@ namespace Ngf
 
     private slots:
         void playPendingReply(QDBusPendingCallWatcher *watcher);
-        void eventStatus(quint32 serverEventId, quint32 state);
+        void setEventState(quint32 serverEventId, quint32 state);
         void serviceRegistered(const QString &service);
         void serviceUnregistered(const QString &service);
 
     private:
-        void setEventState(Event *event, EventState wantedState);
+        void requestEventState(Event *event, EventState wantedState);
         void removeEvent(Event *event);
         void removeAllEvents();
         bool changeState(quint32 clientEventId, EventState wantedState);


### PR DESCRIPTION
If calling e.g. stop() twice both of those request were passed to ngfd which at later moment didn't anymore have the event with such id, got confused and issued warnings.

Some details adjusted:
- State change method bool return values are defined as "False if no connection to NGF daemon", so making them behave as such. Though didn't find any place interested in the return values.
- Some methods renamed a bit to match better what they do, e.g. set or request something.
- Splitted the pending state change requested to its own member variable to keep it simpler. Active state is now what's reported active by the server and wanted state is what's requested the last time from the server, protecting against requesting same thing many times.
