### PR TITLE
Avoid blocking d-bus

### DIFF
--- a/declarative/src/declarativengfevent.cpp
+++ b/declarative/src/declarativengfevent.cpp
@@ -131,7 +131,6 @@ void DeclarativeNgfEvent::play()
     if (m_eventId)
         stop();
 
-
     if (!m_event.isEmpty() && isConnected()) {
         if (m_properties.count() > 0) {
             QMap<QString, QVariant> prop;

--- a/rpm/libngf-qt5.spec
+++ b/rpm/libngf-qt5.spec
@@ -61,12 +61,9 @@ Requires:   %{name} = %{version}-%{release}
 
 %build
 %qmake5 "VERSION=$(sed 's/+.*//' <<<"%{version}")"
-
-make %{?_smp_mflags}
-
+%make_build
 
 %install
-rm -rf %{buildroot}
 %qmake_install
 
 # org.nemomobile.ngf legacy import
@@ -79,29 +76,24 @@ sed 's/Nemo.Ngf/org.nemomobile.ngf/' < declarative/qmldir > %{buildroot}%{_libdi
 %postun -p /sbin/ldconfig
 
 %files
-%defattr(-,root,root,-)
 %{_libdir}/libngf-qt5.so.*
 %license COPYING
 
 %files qtfeedback
-%defattr(-,root,root,-)
 %{_libdir}/qt5/plugins/feedback/libqtfeedback_libngf.so
 %{_libdir}/qt5/plugins/feedback/libngf.json
 
 %files devel
-%defattr(-,root,root,-)
 %{_libdir}/libngf-qt5.so
 %{_includedir}/ngf-qt5/*.h
 %{_includedir}/ngf-qt5/NgfClient
 %{_libdir}/pkgconfig/ngf-qt5.pc
 
 %files declarative
-%defattr(-,root,root,-)
 %{_libdir}/qt5/qml/Nemo/Ngf/
 
 # org.nemomobile.ngf legacy import
 %{_libdir}/qt5/qml/org/nemomobile/ngf/
 
 %files tests
-%defattr(-,root,root,-)
 /opt/tests/libngf-qt5/

--- a/src/dbus/client.cpp
+++ b/src/dbus/client.cpp
@@ -26,7 +26,8 @@
 
 Ngf::Client::Client(QObject *parent)
     : QObject(parent), d_ptr(new ClientPrivate(this))
-{}
+{
+}
 
 Ngf::Client::~Client()
 {

--- a/src/dbus/clientprivate.h
+++ b/src/dbus/clientprivate.h
@@ -65,7 +65,6 @@ namespace Ngf
     private slots:
         void playPendingReply(QDBusPendingCallWatcher *watcher);
         void setEventState(quint32 serverEventId, quint32 state);
-        void serviceRegistered(const QString &service);
         void serviceUnregistered(const QString &service);
 
     private:
@@ -74,7 +73,6 @@ namespace Ngf
         void removeAllEvents();
         bool changeState(quint32 clientEventId, EventState wantedState);
         bool changeState(const QString &clientEventName, EventState wantedState);
-        void changeAvailable(bool available);
         void changeConnected(bool connected);
 
         Client * const q_ptr;
@@ -82,10 +80,7 @@ namespace Ngf
 
         QLoggingCategory m_log;
         QDBusServiceWatcher *m_serviceWatcher;
-        bool m_connectionWanted;
-        bool m_available;
         bool m_connected;
-        QDBusInterface *m_iface;
         quint32 m_clientEventId; // Internal counter for client event ids, incremented every time play is called.
         QList<Event*> m_events;
     };

--- a/tests/testbase.h
+++ b/tests/testbase.h
@@ -510,8 +510,6 @@ inline void TestBase::NgfdMock::mock_disconnectForAWhile(const QDBusMessage &mes
     }
 }
 
-#define COMPAT_APPLICATION_CLASS QCoreApplication
-
 #define TEST_MAIN(TestClass)                                                \
     int main(int argc, char *argv[])                                        \
     {                                                                       \
@@ -520,7 +518,7 @@ inline void TestBase::NgfdMock::mock_disconnectForAWhile(const QDBusMessage &mes
                                                                             \
         if (argc == 2 && argv[1] == QLatin1String("--mock")) {              \
             Ngf::Tests::TestBase::NgfdMock::installMsgHandler();            \
-            COMPAT_APPLICATION_CLASS app(argc, argv);                       \
+            QCoreApplication app(argc, argv);                               \
                                                                             \
             qDebug("%s: starting...", Q_FUNC_INFO);                         \
                                                                             \
@@ -528,7 +526,7 @@ inline void TestBase::NgfdMock::mock_disconnectForAWhile(const QDBusMessage &mes
                                                                             \
             return app.exec();                                              \
         } else {                                                            \
-            COMPAT_APPLICATION_CLASS app(argc, argv);                       \
+            QCoreApplication app(argc, argv);                               \
                                                                             \
             TestClass test;                                                 \
                                                                             \

--- a/tests/ut_client.cpp
+++ b/tests/ut_client.cpp
@@ -52,8 +52,6 @@ void UtClient::initTestCase()
 
     m_client = new Client(this);
 
-    QDBusInterface client(service(), path(),interface(), bus());
-
     SignalSpy connectionStatusSpy(m_client, SIGNAL(connectionStatus(bool)));
 
     QVERIFY(m_client->connect());
@@ -109,9 +107,9 @@ void UtClient::testPlay()
 
 void UtClient::testPause()
 {
-    QDBusInterface client(service(), path(),interface(), bus());
+    QDBusInterface mockService(service(), path(), interface(), bus());
 
-    SignalSpy pauseCalledSpy(&client, SIGNAL(mock_pauseCalled(quint32,bool)));
+    SignalSpy pauseCalledSpy(&mockService, SIGNAL(mock_pauseCalled(quint32,bool)));
 
     SignalSpy eventPausedSpy(m_client, SIGNAL(eventPaused(quint32)));
 
@@ -140,9 +138,9 @@ void UtClient::testPause()
 
 void UtClient::testStop()
 {
-    QDBusInterface client(service(), path(),interface(), bus());
+    QDBusInterface mockService(service(), path(), interface(), bus());
 
-    SignalSpy stopCalledSpy(&client, SIGNAL(mock_stopCalled(uint)));
+    SignalSpy stopCalledSpy(&mockService, SIGNAL(mock_stopCalled(uint)));
 
     SignalSpy eventCompletedSpy(m_client, SIGNAL(eventCompleted(quint32)));
 
@@ -157,9 +155,9 @@ void UtClient::testStop()
 
 void UtClient::testFail()
 {
-    QDBusInterface client(service(), path(),interface(), bus());
+    QDBusInterface mockService(service(), path(), interface(), bus());
 
-    SignalSpy playCalledSpy(&client, SIGNAL(mock_playCalled(QString,QVariantMap)));
+    SignalSpy playCalledSpy(&mockService, SIGNAL(mock_playCalled(QString,QVariantMap)));
 
     QVariantMap properties;
     properties["foo"] = "fooval";
@@ -179,7 +177,7 @@ void UtClient::testFail()
 
     SignalSpy eventFailedSpy(m_client, SIGNAL(eventFailed(quint32)));
 
-    client.call("mock_fail", "an-event");
+    mockService.call("mock_fail", "an-event");
 
     QVERIFY(waitForSignal(&eventFailedSpy));
     QCOMPARE(eventFailedSpy.count(), 1);
@@ -188,9 +186,9 @@ void UtClient::testFail()
 
 void UtClient::testPlayFail()
 {
-    QDBusInterface client(service(), path(),interface(), bus());
+    QDBusInterface mockService(service(), path(), interface(), bus());
 
-    SignalSpy playCalledSpy(&client, SIGNAL(mock_playCalled(QString,QVariantMap)));
+    SignalSpy playCalledSpy(&mockService, SIGNAL(mock_playCalled(QString,QVariantMap)));
     SignalSpy eventPlayingSpy(m_client, SIGNAL(eventPlaying(quint32)));
     SignalSpy eventFailedSpy(m_client, SIGNAL(eventFailed(quint32)));
 
@@ -198,7 +196,7 @@ void UtClient::testPlayFail()
     properties["foo"] = "fooval";
     properties["bar"] = 42;
 
-    client.call("mock_failNextPlay");
+    mockService.call("mock_failNextPlay");
 
     quint32 id = m_client->play("an-event", properties);
     QVERIFY(id > 0);
@@ -219,11 +217,11 @@ void UtClient::testPlayFail()
 void UtClient::testConnectionStatus()
 {
     QSKIP("Libngf-qt not currently tracking the daemon availability");
-    QDBusInterface client(service(), path(),interface(), bus());
+    QDBusInterface mockService(service(), path(), interface(), bus());
 
     SignalSpy connectionStatusSpy(m_client, SIGNAL(connectionStatus(bool)));
 
-    client.call("mock_disconnectForAWhile");
+    mockService.call("mock_disconnectForAWhile");
 
     QList<bool> expected = QList<bool>() << false << true;
     while (!expected.isEmpty()) {
@@ -238,7 +236,7 @@ void UtClient::testConnectionStatus()
 
 void UtClient::testFastPlayStop()
 {
-    QDBusInterface client(service(), path(),interface(), bus());
+    QDBusInterface mockService(service(), path(), interface(), bus());
 
     SignalSpy eventCompletedSpy(m_client, SIGNAL(eventCompleted(quint32)));
 

--- a/tests/ut_client.cpp
+++ b/tests/ut_client.cpp
@@ -218,6 +218,7 @@ void UtClient::testPlayFail()
 
 void UtClient::testConnectionStatus()
 {
+    QSKIP("Libngf-qt not currently tracking the daemon availability");
     QDBusInterface client(service(), path(),interface(), bus());
 
     SignalSpy connectionStatusSpy(m_client, SIGNAL(connectionStatus(bool)));

--- a/tests/ut_declarativengfevent.cpp
+++ b/tests/ut_declarativengfevent.cpp
@@ -344,6 +344,7 @@ void UtDeclarativeNgfEvent::testPlayFail()
 
 void UtDeclarativeNgfEvent::testConnectionStatus()
 {
+    QSKIP("Libngf-qt not currently tracking the daemon availability");
     QDBusInterface client(service(), path(), interface(), bus());
 
     DeclarativeExpression connectedExpression(m_engine->rootContext(), m_instance, "connected");

--- a/tests/ut_declarativengfevent.cpp
+++ b/tests/ut_declarativengfevent.cpp
@@ -135,7 +135,7 @@ void UtDeclarativeNgfEvent::testEventProperty()
 
 void UtDeclarativeNgfEvent::testPlay()
 {
-    QDBusInterface client(service(), path(),interface(), bus());
+    QDBusInterface mockService(service(), path(), interface(), bus());
 
     QQmlExpression statusExpression(m_engine->rootContext(), m_instance, "status");
     statusExpression.setNotifyOnValueChanged(true);
@@ -143,7 +143,7 @@ void UtDeclarativeNgfEvent::testPlay()
     QVERIFY2(!statusExpression.hasError(), qPrintable(statusExpression.error().toString()));
     SignalSpy statusSpy(&statusExpression, SIGNAL(valueChanged()));
 
-    SignalSpy playCalledSpy(&client, SIGNAL(mock_playCalled(QString,QVariantMap)));
+    SignalSpy playCalledSpy(&mockService, SIGNAL(mock_playCalled(QString,QVariantMap)));
 
     QQmlExpression playExpression(m_engine->rootContext(), m_instance, "play()");
     playExpression.evaluate();
@@ -165,7 +165,7 @@ void UtDeclarativeNgfEvent::testPlay()
 
 void UtDeclarativeNgfEvent::testPause()
 {
-    QDBusInterface client(service(), path(),interface(), bus());
+    QDBusInterface mockService(service(), path(), interface(), bus());
 
     QQmlExpression statusExpression(m_engine->rootContext(), m_instance, "status");
     statusExpression.setNotifyOnValueChanged(true);
@@ -173,7 +173,7 @@ void UtDeclarativeNgfEvent::testPause()
     QVERIFY2(!statusExpression.hasError(), qPrintable(statusExpression.error().toString()));
     SignalSpy statusSpy(&statusExpression, SIGNAL(valueChanged()));
 
-    SignalSpy pauseCalledSpy(&client, SIGNAL(mock_pauseCalled(quint32,bool)));
+    SignalSpy pauseCalledSpy(&mockService, SIGNAL(mock_pauseCalled(quint32,bool)));
 
     QQmlExpression pauseExpression(m_engine->rootContext(), m_instance, "pause()");
     pauseExpression.evaluate();
@@ -207,7 +207,7 @@ void UtDeclarativeNgfEvent::testPause()
 
 void UtDeclarativeNgfEvent::testStop()
 {
-    QDBusInterface client(service(), path(),interface(), bus());
+    QDBusInterface mockService(service(), path(), interface(), bus());
 
     QQmlExpression statusExpression(m_engine->rootContext(), m_instance, "status");
     statusExpression.setNotifyOnValueChanged(true);
@@ -215,7 +215,7 @@ void UtDeclarativeNgfEvent::testStop()
     QVERIFY2(!statusExpression.hasError(), qPrintable(statusExpression.error().toString()));
     SignalSpy statusSpy(&statusExpression, SIGNAL(valueChanged()));
 
-    SignalSpy stopCalledSpy(&client, SIGNAL(mock_stopCalled(uint)));
+    SignalSpy stopCalledSpy(&mockService, SIGNAL(mock_stopCalled(uint)));
 
     QQmlExpression stopExpression(m_engine->rootContext(), m_instance, "stop()");
     stopExpression.evaluate();
@@ -232,7 +232,7 @@ void UtDeclarativeNgfEvent::testStop()
 
 void UtDeclarativeNgfEvent::testStopOutside()
 {
-    QDBusInterface client(service(), path(),interface(), bus());
+    QDBusInterface mockService(service(), path(), interface(), bus());
 
     QQmlExpression statusExpression(m_engine->rootContext(), m_instance, "status");
     statusExpression.setNotifyOnValueChanged(true);
@@ -240,7 +240,7 @@ void UtDeclarativeNgfEvent::testStopOutside()
     QVERIFY2(!statusExpression.hasError(), qPrintable(statusExpression.error().toString()));
     SignalSpy statusSpy(&statusExpression, SIGNAL(valueChanged()));
 
-    SignalSpy playCalledSpy(&client, SIGNAL(mock_playCalled(QString,QVariantMap)));
+    SignalSpy playCalledSpy(&mockService, SIGNAL(mock_playCalled(QString,QVariantMap)));
 
     QQmlExpression playExpression(m_engine->rootContext(), m_instance, "play()");
     playExpression.evaluate();
@@ -261,7 +261,7 @@ void UtDeclarativeNgfEvent::testStopOutside()
 
     statusSpy.clear();
 
-    client.call("mock_stop", "an-event");
+    mockService.call("mock_stop", "an-event");
 
     QVERIFY(waitForSignals(SignalSpyList() << &statusSpy));
     QCOMPARE(statusSpy.count(), 1);
@@ -272,7 +272,7 @@ void UtDeclarativeNgfEvent::testStopOutside()
 
 void UtDeclarativeNgfEvent::testFail()
 {
-    QDBusInterface client(service(), path(),interface(), bus());
+    QDBusInterface mockService(service(), path(), interface(), bus());
 
     QQmlExpression statusExpression(m_engine->rootContext(), m_instance, "status");
     statusExpression.setNotifyOnValueChanged(true);
@@ -280,7 +280,7 @@ void UtDeclarativeNgfEvent::testFail()
     QVERIFY2(!statusExpression.hasError(), qPrintable(statusExpression.error().toString()));
     SignalSpy statusSpy(&statusExpression, SIGNAL(valueChanged()));
 
-    SignalSpy playCalledSpy(&client, SIGNAL(mock_playCalled(QString,QVariantMap)));
+    SignalSpy playCalledSpy(&mockService, SIGNAL(mock_playCalled(QString,QVariantMap)));
 
     QQmlExpression playExpression(m_engine->rootContext(), m_instance, "play()");
     playExpression.evaluate();
@@ -301,7 +301,7 @@ void UtDeclarativeNgfEvent::testFail()
 
     statusSpy.clear();
 
-    client.call("mock_fail", "an-event");
+    mockService.call("mock_fail", "an-event");
 
     QVERIFY(waitForSignal(&statusSpy));
     QCOMPARE(statusSpy.count(), 1);
@@ -312,7 +312,7 @@ void UtDeclarativeNgfEvent::testFail()
 
 void UtDeclarativeNgfEvent::testPlayFail()
 {
-    QDBusInterface client(service(), path(),interface(), bus());
+    QDBusInterface mockService(service(), path(), interface(), bus());
 
     QQmlExpression statusExpression(m_engine->rootContext(), m_instance, "status");
     statusExpression.setNotifyOnValueChanged(true);
@@ -320,9 +320,9 @@ void UtDeclarativeNgfEvent::testPlayFail()
     QVERIFY2(!statusExpression.hasError(), qPrintable(statusExpression.error().toString()));
     SignalSpy statusSpy(&statusExpression, SIGNAL(valueChanged()));
 
-    SignalSpy playCalledSpy(&client, SIGNAL(mock_playCalled(QString,QVariantMap)));
+    SignalSpy playCalledSpy(&mockService, SIGNAL(mock_playCalled(QString,QVariantMap)));
 
-    client.call("mock_failNextPlay");
+    mockService.call("mock_failNextPlay");
 
     QQmlExpression playExpression(m_engine->rootContext(), m_instance, "play()");
     playExpression.evaluate();
@@ -345,7 +345,7 @@ void UtDeclarativeNgfEvent::testPlayFail()
 void UtDeclarativeNgfEvent::testConnectionStatus()
 {
     QSKIP("Libngf-qt not currently tracking the daemon availability");
-    QDBusInterface client(service(), path(), interface(), bus());
+    QDBusInterface mockService(service(), path(), interface(), bus());
 
     DeclarativeExpression connectedExpression(m_engine->rootContext(), m_instance, "connected");
     connectedExpression.setNotifyOnValueChanged(true);
@@ -353,7 +353,7 @@ void UtDeclarativeNgfEvent::testConnectionStatus()
     QVERIFY2(!connectedExpression.hasError(), qPrintable(connectedExpression.error().toString()));
     SignalSpy connectedSpy(&connectedExpression, SIGNAL(valueChanged(QVariant)));
 
-    client.call("mock_disconnectForAWhile");
+    mockService.call("mock_disconnectForAWhile");
 
     QList<bool> expected = QList<bool>() << false << true;
     while (!expected.isEmpty()) {


### PR DESCRIPTION
Main commit

    [libngf-qt] Simplify d-bus client by avoiding startup round-trips. JB#62786
    
    The initial setup was able to get the process blocking if ngfd
    was being unresponsive. Furthermore the name owner fetching
    on startup and QDBusInterface creation both do a round-trip.
    
    We don't really need to know at startup whether NGFD is there to serve.
    We can just fire up events and they will end up as eventFailed
    if there's some problem. If needed, the API can be augmented to separate
    the ngfd not running case, but so far there seems quite little interest
    in client side whether the play requests succeed.
