### PR TITLE
Fixup build with qt6

### DIFF
--- a/tests/testbase.h
+++ b/tests/testbase.h
@@ -1,6 +1,7 @@
 #ifndef TESTBASE_H
 #define TESTBASE_H
 
+#include <QtCore/QObject>
 #include <QtCore/QMetaProperty>
 #include <QtCore/QObject>
 #include <QtCore/QPointer>
@@ -123,13 +124,14 @@ private:
  *    It connects the signals to QEventLoop::quit(). When used together with QDBusInterface, it is
  *    usually too late to connect -- that is why the signalEmitted() signal exists.
  */
-class TestBase::SignalSpy : public QSignalSpy
+class TestBase::SignalSpy : public QObject, public QSignalSpy
 {
     Q_OBJECT
 
 public:
     SignalSpy(QObject *object, const char *signal)
-        : QSignalSpy(object, signal)
+        : QObject()
+        , QSignalSpy(object, signal)
     {
         connect(object, signal, this, SIGNAL(signalEmitted()));
     }

--- a/tests/testbase.h
+++ b/tests/testbase.h
@@ -124,14 +124,23 @@ private:
  *    It connects the signals to QEventLoop::quit(). When used together with QDBusInterface, it is
  *    usually too late to connect -- that is why the signalEmitted() signal exists.
  */
-class TestBase::SignalSpy : public QObject, public QSignalSpy
+class TestBase::SignalSpy
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
+   : public QObject, public QSignalSpy
+#else
+   : public QSignalSpy
+#endif
 {
     Q_OBJECT
 
 public:
     SignalSpy(QObject *object, const char *signal)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
         : QObject()
         , QSignalSpy(object, signal)
+#else
+        : QSignalSpy(object, signal)
+#endif
     {
         connect(object, signal, this, SIGNAL(signalEmitted()));
     }


### PR DESCRIPTION
Tests are not compiling with Qt6 with following error message.
```
testbase.h: In constructor 'Ngf::Tests::TestBase::SignalSpy::SignalSpy(QObject*, const char*)':
testbase.h:134:16: error: no matching function for call to 'QObject::connect(QObject*&, const char*&, Ngf::Tests::TestBase::SignalSpy*, const char [17])'
  134 |         connect(object, signal, this, SIGNAL(signalEmitted()));
      |         ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/qt6/QtCore/qvariant.h:26,
                 from /usr/include/qt6/QtDBus/qtdbusglobal.h:9,
                 from /usr/include/qt6/QtDBus/qdbuspendingcall.h:7,
                 from /usr/include/qt6/QtDBus/QDBusPendingCallWatcher:1,
                 from ut_client.cpp:2:
/usr/include/qt6/QtCore/qobject.h:228:9: note: candidate: 'template<class Func1, class Func2> static QMetaObject::Connection QObject::connect(const typename QtPrivate::FunctionPointer<Prototype>::Object*, Func1, const typename QtPrivate::ContextTypeForFunctor<Func2>::ContextType*, Func2&&, Qt::ConnectionType)'
  228 |         connect(const typename QtPrivate::FunctionPointer<Func1>::Object *sender, Func1 signal,
      |         ^~~~~~~
/usr/include/qt6/QtCore/qobject.h:228:9: note:   template argument deduction/substitution failed:
/usr/include/qt6/QtCore/qobject.h: In substitution of 'template<class Func1, class Func2> static QMetaObject::Connection QObject::connect(const typename QtPrivate::FunctionPointer<Prototype>::Object*, Func1, const typename QtPrivate::ContextTypeForFunctor<Func2>::ContextType*, Func2&&, Qt::ConnectionType) [with Func1 = const char*; Func2 = const char (&)[17]]':
testbase.h:134:16:   required from here
  134 |         connect(object, signal, this, SIGNAL(signalEmitted()));
      |         ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/qt6/QtCore/qobject.h:228:9: error: no type named 'Object' in 'struct QtPrivate::FunctionPointer<const char*>'
  228 |         connect(const typename QtPrivate::FunctionPointer<Func1>::Object *sender, Func1 signal,
      |         ^~~~~~~
/usr/include/qt6/QtCore/qobject.h:277:9: note: candidate: 'template<class Func1, class Func2> static QMetaObject::Connection QObject::connect(const typename QtPrivate::FunctionPointer<Prototype>::Object*, Func1, Func2&&)'
  277 |         connect(const typename QtPrivate::FunctionPointer<Func1>::Object *sender, Func1 signal, Func2 &&slot)
      |         ^~~~~~~
/usr/include/qt6/QtCore/qobject.h:277:9: note:   candidate expects 3 arguments, 4 provided
/usr/include/qt6/QtCore/qobject.h:207:36: note: candidate: 'static QMetaObject::Connection QObject::connect(const QObject*, const char*, const QObject*, const char*, Qt::ConnectionType)'
  207 |     static QMetaObject::Connection connect(const QObject *sender, const char *signal,
      |                                    ^~~~~~~
```

I think @neochapay forgot to include that patch into https://github.com/sailfishos/libngf-qt/pull/4