### PR TITLE
[libngf-qt] Use pkgconfig for QtFeedback. JB#61015

### DIFF
--- a/feedback/feedback.pro
+++ b/feedback/feedback.pro
@@ -1,8 +1,9 @@
 TEMPLATE = lib
 
-QT += core feedback
-CONFIG += qt plugin hide_symbols
+QT += core
+CONFIG += qt plugin hide_symbols link_pkgconfig
 QT -= gui
+PKGCONFIG += Qt5Feedback
 
 TARGET = $$qtLibraryTarget(qtfeedback_libngf)
 PLUGIN_TYPE = feedback


### PR DESCRIPTION
Qt module support might be going away due to qt6 port, and anyway the build requirement here is with pkgconfig.

Related to https://github.com/sailfishos/qtfeedback/pull/2